### PR TITLE
Fix memory leak

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -122,6 +122,8 @@ void Reindexer::get_bag_files(
     }
   } while (rcutils_dir_iter_next(dir_iter));
 
+   rcutils_dir_iter_end(dir_iter);
+
   // Sort relative file path by database number
   std::sort(
     output.begin(), output.end(),


### PR DESCRIPTION
Fixing memory leak in bag reindexer. Deallocation of directory iterator was not performed. In accordance with description of `rclutils_dir_iter_start`, a call to `rclutils_dir_iter_end` on the directory iterator must be performed in order to not leak memory.
```
/// Begin iterating over the contents of the specified directory.
/**
 * This function is used to list the files and directories that are contained in
 * a specified directory. The structure returned by it must be deallocated using
 * ::rcutils_dir_iter_end when the iteration is completed. The name of the
 * enumerated entry is stored in the `entry_name` member of the returned object,
 * and the first entry is already populated upon completion of this function. To
 * populate the entry with the name of the next entry, use the
 * ::rcutils_dir_iter_next function. Note that the "." and ".." entries are
 * typically among the entries enumerated.
 * \param[in] directory_path The directory path to iterate over the contents of.
 * \param[in] allocator Allocator used to create the returned structure.
 * \return An iterator object used to continue iterating directory contents
 * \return NULL if an error occurred
 */
RCUTILS_PUBLIC
rcutils_dir_iter_t *
rcutils_dir_iter_start(const char * directory_path, const rcutils_allocator_t allocator);
```