### PR TITLE
Fix clang compilation error. non const lvalue cannot be bound to temp…

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -44,8 +44,8 @@ public:
   }
 
   void open(
-    rosbag2_storage::StorageOptions & storage_options,
-    rosbag2_cpp::ConverterOptions & converter_options = rosbag2_cpp::ConverterOptions())
+    const rosbag2_storage::StorageOptions & storage_options,
+    const rosbag2_cpp::ConverterOptions & converter_options = rosbag2_cpp::ConverterOptions())
   {
     reader_->open(storage_options, converter_options);
   }


### PR DESCRIPTION
Fix for bug in upstream changes.
A non-const lvalue cannot be bound to a temporary.