### PR TITLE
Fixes clang compiler error introduced by #1404.

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -45,7 +45,7 @@ public:
 
   void open(
     rosbag2_storage::StorageOptions & storage_options,
-    rosbag2_cpp::ConverterOptions & converter_options = rosbag2_cpp::ConverterOptions())
+    const rosbag2_cpp::ConverterOptions & converter_options = rosbag2_cpp::ConverterOptions())
   {
     reader_->open(storage_options, converter_options);
   }


### PR DESCRIPTION
```
rosbag2_py/src/rosbag2_py/_reader.cpp:48:37: error: non-const lvalue reference to type 'rosbag2_cpp::ConverterOptions' cannot bind to a temporary of type 'rosbag2_cpp::ConverterOptions'
    rosbag2_cpp::ConverterOptions & converter_options = rosbag2_cpp::ConverterOptions())
                                    ^                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

A non-const lvalue reference cannot be bound to a temporary.